### PR TITLE
Add "Deprecated" to ReadMe

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,8 @@
-# IBM Z Optimized for TensorFlow Documentation
+# Deprecated
+
+- **Please visit [ibm-zdnn-plugin](https://github.com/IBM/ibm-zdnn-plugin).**
+
+# Deprecated - IBM Z Optimized for TensorFlow Documentation
 
 ## Table of Contents
 1. [Overview](#Overview)


### PR DESCRIPTION
- As per the new release of `ibm-zdnn-plugin`, the `ibmz-optimized-for-tensorflow` page is now deprecated
- New link, https://github.com/IBM/ibm-zdnn-plugin